### PR TITLE
Handle iTunes API not responding with JSON

### DIFF
--- a/build/search/search.js
+++ b/build/search/search.js
@@ -8,12 +8,14 @@ function searchItunes(options) {
         const phin = require("phin");
         //Initializing passed options (adding methods when directly passing an object)
         const searchOptions = search_options_1.ItunesSearchOptions.from(options);
-        phin(`${exports.itunesSearchRoot}?${searchOptions.toURI()}`, (err, res) => {
+        phin({
+            url: `${exports.itunesSearchRoot}?${searchOptions.toURI()}`,
+            parse: 'json',
+        }, (err, res) => {
             if (err) {
                 reject(err);
             }
             else {
-                res.body = JSON.parse(res.body);
                 resolve(result_1.ItunesResult.from(res.body));
             }
         });

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -10,11 +10,13 @@ export function searchItunes(options: ISearchOptions | ItunesSearchOptions): Pro
     //Initializing passed options (adding methods when directly passing an object)
     const searchOptions: ItunesSearchOptions = ItunesSearchOptions.from(options);
 
-    phin(`${itunesSearchRoot}?${searchOptions.toURI()}`, (err: any, res: any) => {
+    phin({
+      url: `${itunesSearchRoot}?${searchOptions.toURI()}`,
+      parse: 'json',
+    }, (err: any, res: any) => {
       if (err) {
         reject(err);
       } else {
-        res.body = JSON.parse(res.body);
         resolve(ItunesResult.from(res.body));
       }
     });


### PR DESCRIPTION
Once in a while, iTunes API responds with an HTML error response:
```html
<html><head><title>Error</title></head><body>Your request produced an error.  <BR>[newNullResponse]</body></html>
```

`JSON.parse()` fails in search.ts, and Node exits with a fatal error instead of rejecting the Promise returned by `searchItunes()`.

Have `phin` attempt to parse response as JSON instead of doing it manually so that invalid response simply results a in rejected Promise and Node does not crash.